### PR TITLE
Add option to ignore cancelled InteractEvent (#53)

### DIFF
--- a/modules/betterchairs-api/src/main/java/de/sprax2013/betterchairs/Settings.java
+++ b/modules/betterchairs-api/src/main/java/de/sprax2013/betterchairs/Settings.java
@@ -38,6 +38,10 @@ public class Settings {
     public static final ConfigEntry NEEDS_SIGNS = config.createEntry(
             "Chairs.NeedsSignsOnBothSides", false,
             "Does a chair need signs on both sides attached to be detected as an chair");
+    public static final ConfigEntry IGNORES_INTERACT_PREVENTION = config.createEntry(
+            "Chairs.IgnoreOtherPluginsPreventingInteract", false,
+            "Enable this if you want players to be able to sit on chairs while other plugins " +
+                    "(like WorldGuard or PlotSquared) are not allowing interactions/use with the chair blocks.");
 
     public static final ConfigEntry USE_STAIRS = config.createEntry(
             "Chairs.UseStairs", true, "Can stairs be chairs?");

--- a/modules/betterchairs-plugin/src/main/java/de/sprax2013/betterchairs/EventListener.java
+++ b/modules/betterchairs-plugin/src/main/java/de/sprax2013/betterchairs/EventListener.java
@@ -7,7 +7,6 @@ import org.bukkit.block.BlockFace;
 import org.bukkit.entity.ArmorStand;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
-import org.bukkit.event.Event;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
@@ -38,8 +37,9 @@ public class EventListener implements Listener {
      * If a player is interacting with a valid block to be used as a Chair,
      * we spawn a Chair and sit the player on it
      */
-    @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
+    @EventHandler(priority = EventPriority.HIGH)
     private void onInteract(PlayerInteractEvent e) {
+        if (e.isCancelled() && !Settings.IGNORES_INTERACT_PREVENTION.getValueAsBoolean()) return;
         if (e.getAction() != Action.RIGHT_CLICK_BLOCK) return;
 
         // Check Player
@@ -116,10 +116,12 @@ public class EventListener implements Listener {
         }
 
         // Spawn Chair
-        e.setUseItemInHand(Event.Result.DENY);
+        if (getManager().create(e.getPlayer(), e.getClickedBlock())) {
+            e.setCancelled(true);
 
-        if (getManager().create(e.getPlayer(), e.getClickedBlock()) && Settings.MSG_NOW_SITTING.getValueAsBoolean()) {
-            e.getPlayer().sendMessage(Messages.getString(Messages.USE_NOW_SITTING));
+            if (Settings.MSG_NOW_SITTING.getValueAsBoolean()) {
+                e.getPlayer().sendMessage(Messages.getString(Messages.USE_NOW_SITTING));
+            }
         }
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
     <properties>
         <pluginName>BetterChairs</pluginName>
 
-        <maven.compiler.release>1.8</maven.compiler.release>
+        <maven.compiler.release>8</maven.compiler.release>
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.compiler.source>1.8</maven.compiler.source>
 


### PR DESCRIPTION
> If you want players to be able to sit on chairs while other plugins (like WorldGuard or PlotSquared) are not allowing interactions/use with the chair blocks.

closes #53