### PR TITLE
Update dependency item-nbt-api and bstats-bukkit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ _yyyy-mm-dd_ [GitHub Diff](https://github.com/SpraxDev/BetterChairs/compare/prev
 * Line 2
 -->
 
+## Unreleased
+<!-- _yyyy-mm-dd_ [GitHub Diff](https://github.com/SpraxDev/BetterChairs/compare/v1.2.0...curr-tag-name) -->
+
+### Changed
+* Updated dependency `item-nbt-api` from `2.6.0` to `2.6.1`
+* Updated dependency `bstats-bukkit` from `1.7` to `1.8`
+
+
 ## Version 1.2.0
 _2020-11-08_ [GitHub Diff](https://github.com/SpraxDev/BetterChairs/compare/v1.1.0...v1.2.0)
 

--- a/modules/betterchairs-api/pom.xml
+++ b/modules/betterchairs-api/pom.xml
@@ -100,7 +100,7 @@
         <dependency>
             <groupId>de.tr7zw</groupId>
             <artifactId>item-nbt-api</artifactId>
-            <version>2.6.0</version>
+            <version>2.6.1</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/modules/betterchairs-plugin/pom.xml
+++ b/modules/betterchairs-plugin/pom.xml
@@ -121,7 +121,7 @@
         <dependency>
             <groupId>org.bstats</groupId>
             <artifactId>bstats-bukkit</artifactId>
-            <version>1.7</version>
+            <version>1.8</version>
             <scope>compile</scope>
         </dependency>
 


### PR DESCRIPTION
* `item-nbt-api` from `2.6.0` to `2.6.1`
* `bstats-bukkit` from `1.7` to `1.8`