### PR TITLE
Relocate most classes [BREAKING CHANGE]

### DIFF
--- a/modules/betterchairs-api/pom.xml
+++ b/modules/betterchairs-api/pom.xml
@@ -31,12 +31,12 @@
                             <relocations>
                                 <relocation>
                                     <pattern>de.tr7zw.changeme.nbtapi</pattern>
-                                    <shadedPattern>de.sprax2013.betterchairs.tr7zw.nbtapi</shadedPattern>
+                                    <shadedPattern>de.sprax2013.betterchairs.dependencies.de.tr7zw.nbtapi</shadedPattern>
                                 </relocation>
 
                                 <relocation>
                                     <pattern>de.sprax2013.lime</pattern>
-                                    <shadedPattern>de.sprax2013.betterchairs.sprax2013.lime</shadedPattern>
+                                    <shadedPattern>de.sprax2013.betterchairs.dependencies.de.sprax2013.lime</shadedPattern>
                                 </relocation>
                             </relocations>
                         </configuration>

--- a/modules/betterchairs-api/src/main/java/de/sprax2013/betterchairs/api/Chair.java
+++ b/modules/betterchairs-api/src/main/java/de/sprax2013/betterchairs/api/Chair.java
@@ -29,22 +29,6 @@ public class Chair {
     }
 
     /**
-     * This method checks if it is a stair block.<br>
-     * <s>Currently only Stairs and Slabs may be used for chairs.</s>
-     *
-     * @return true if the chair's block is a stair, false otherwise
-     *
-     * @see #getType()
-     * @deprecated Since v1.1.0 Chairs may be any block and not just stairs and slabs
-     */
-    @Deprecated
-    public boolean isStair() {
-        if (ChairManager.getInstance() == null) throw new IllegalStateException(ERR_MANAGER_NOT_AVAILABLE);
-
-        return ChairManager.getInstance().chairNMS.isStair(block);
-    }
-
-    /**
      * This method checks if it is a stair or slab block.<br>
      *
      * @return true if the chair's block is a stair, false otherwise

--- a/modules/betterchairs-api/src/main/java/de/sprax2013/betterchairs/api/Chair.java
+++ b/modules/betterchairs-api/src/main/java/de/sprax2013/betterchairs/api/Chair.java
@@ -1,5 +1,6 @@
-package de.sprax2013.betterchairs;
+package de.sprax2013.betterchairs.api;
 
+import de.sprax2013.betterchairs.files.Settings;
 import org.bukkit.Location;
 import org.bukkit.block.Block;
 import org.bukkit.entity.ArmorStand;

--- a/modules/betterchairs-api/src/main/java/de/sprax2013/betterchairs/api/ChairManager.java
+++ b/modules/betterchairs-api/src/main/java/de/sprax2013/betterchairs/api/ChairManager.java
@@ -1,7 +1,9 @@
-package de.sprax2013.betterchairs;
+package de.sprax2013.betterchairs.api;
 
-import de.sprax2013.betterchairs.events.PlayerEnterChairEvent;
-import de.sprax2013.betterchairs.events.PlayerLeaveChairEvent;
+import de.sprax2013.betterchairs.api.events.PlayerEnterChairEvent;
+import de.sprax2013.betterchairs.api.events.PlayerLeaveChairEvent;
+import de.sprax2013.betterchairs.files.Messages;
+import de.sprax2013.betterchairs.files.Settings;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.block.Block;
@@ -21,14 +23,14 @@ import java.util.logging.Logger;
  * {@link JavaPlugin#onEnable()} to ensure that other classes relying on it work as intended
  */
 public class ChairManager {
-    protected static JavaPlugin plugin;
-    protected static ChairManager instance;
+    private static JavaPlugin plugin;
+    private static ChairManager instance;
 
     protected final ChairNMS chairNMS;
-    protected final List<Chair> chairs = new ArrayList<>();
-    protected final List<Player> disabled = new ArrayList<>();
+    private final List<Chair> chairs = new ArrayList<>();
+    private final List<Player> disabled = new ArrayList<>();
 
-    protected ChairManager(@NotNull JavaPlugin plugin, @NotNull ChairNMS chairNMS) {
+    public ChairManager(@NotNull JavaPlugin plugin, @NotNull ChairNMS chairNMS) {
         this.chairNMS = Objects.requireNonNull(chairNMS);
 
         instance = this;

--- a/modules/betterchairs-api/src/main/java/de/sprax2013/betterchairs/api/ChairNMS.java
+++ b/modules/betterchairs-api/src/main/java/de/sprax2013/betterchairs/api/ChairNMS.java
@@ -1,5 +1,6 @@
-package de.sprax2013.betterchairs;
+package de.sprax2013.betterchairs.api;
 
+import de.sprax2013.betterchairs.files.Settings;
 import org.bukkit.Location;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
@@ -87,7 +88,10 @@ public abstract class ChairNMS {
     public static int getRegenerationAmplifier(Player p) {
         if (!Settings.REGENERATION_ENABLED.getValueAsBoolean() ||
                 Settings.REGENERATION_AMPLIFIER.getValueAsInt() <= 0 ||
-                !p.hasPermission(ChairManager.plugin.getName() + ".regeneration")) return -1;
+                ChairManager.getPlugin() == null ||
+                !p.hasPermission(ChairManager.getPlugin().getName() + ".regeneration")) {
+            return -1;
+        }
 
         return Settings.REGENERATION_AMPLIFIER.getValueAsInt() - 1;
     }

--- a/modules/betterchairs-api/src/main/java/de/sprax2013/betterchairs/api/ChairType.java
+++ b/modules/betterchairs-api/src/main/java/de/sprax2013/betterchairs/api/ChairType.java
@@ -1,4 +1,4 @@
-package de.sprax2013.betterchairs;
+package de.sprax2013.betterchairs.api;
 
 public enum ChairType {
     STAIR, SLAB, CUSTOM

--- a/modules/betterchairs-api/src/main/java/de/sprax2013/betterchairs/api/ChairUtils.java
+++ b/modules/betterchairs-api/src/main/java/de/sprax2013/betterchairs/api/ChairUtils.java
@@ -1,4 +1,4 @@
-package de.sprax2013.betterchairs;
+package de.sprax2013.betterchairs.api;
 
 import de.tr7zw.changeme.nbtapi.NBTEntity;
 import de.tr7zw.changeme.nbtapi.NbtApiException;

--- a/modules/betterchairs-api/src/main/java/de/sprax2013/betterchairs/api/events/PlayerEnterChairEvent.java
+++ b/modules/betterchairs-api/src/main/java/de/sprax2013/betterchairs/api/events/PlayerEnterChairEvent.java
@@ -1,17 +1,19 @@
-package de.sprax2013.betterchairs.events;
+package de.sprax2013.betterchairs.api.events;
 
-import de.sprax2013.betterchairs.Chair;
+import de.sprax2013.betterchairs.api.Chair;
 import org.bukkit.entity.Player;
+import org.bukkit.event.Cancellable;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
 
-public class PlayerLeaveChairEvent extends Event {
+public class PlayerEnterChairEvent extends Event implements Cancellable {
     public static final HandlerList handlers = new HandlerList();
+    private boolean cancelled = false;
 
     private final Player player;
     private final Chair chair;
 
-    public PlayerLeaveChairEvent(Player player, Chair chair) {
+    public PlayerEnterChairEvent(Player player, Chair chair) {
         this.player = player;
         this.chair = chair;
     }
@@ -20,9 +22,18 @@ public class PlayerLeaveChairEvent extends Event {
         return this.player;
     }
 
-    @SuppressWarnings("unused")
     public Chair getChair() {
         return this.chair;
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return cancelled;
+    }
+
+    @Override
+    public void setCancelled(boolean cancel) {
+        this.cancelled = cancel;
     }
 
     @Override

--- a/modules/betterchairs-api/src/main/java/de/sprax2013/betterchairs/api/events/PlayerLeaveChairEvent.java
+++ b/modules/betterchairs-api/src/main/java/de/sprax2013/betterchairs/api/events/PlayerLeaveChairEvent.java
@@ -1,19 +1,17 @@
-package de.sprax2013.betterchairs.events;
+package de.sprax2013.betterchairs.api.events;
 
-import de.sprax2013.betterchairs.Chair;
+import de.sprax2013.betterchairs.api.Chair;
 import org.bukkit.entity.Player;
-import org.bukkit.event.Cancellable;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
 
-public class PlayerEnterChairEvent extends Event implements Cancellable {
+public class PlayerLeaveChairEvent extends Event {
     public static final HandlerList handlers = new HandlerList();
-    private boolean cancelled = false;
 
     private final Player player;
     private final Chair chair;
 
-    public PlayerEnterChairEvent(Player player, Chair chair) {
+    public PlayerLeaveChairEvent(Player player, Chair chair) {
         this.player = player;
         this.chair = chair;
     }
@@ -22,18 +20,9 @@ public class PlayerEnterChairEvent extends Event implements Cancellable {
         return this.player;
     }
 
+    @SuppressWarnings("unused")
     public Chair getChair() {
         return this.chair;
-    }
-
-    @Override
-    public boolean isCancelled() {
-        return cancelled;
-    }
-
-    @Override
-    public void setCancelled(boolean cancel) {
-        this.cancelled = cancel;
     }
 
     @Override

--- a/modules/betterchairs-api/src/main/java/de/sprax2013/betterchairs/files/ConfigHelper.java
+++ b/modules/betterchairs-api/src/main/java/de/sprax2013/betterchairs/files/ConfigHelper.java
@@ -1,5 +1,6 @@
-package de.sprax2013.betterchairs;
+package de.sprax2013.betterchairs.files;
 
+import de.sprax2013.betterchairs.api.ChairManager;
 import de.sprax2013.lime.configuration.Config;
 import org.bukkit.configuration.file.YamlConfiguration;
 

--- a/modules/betterchairs-api/src/main/java/de/sprax2013/betterchairs/files/Messages.java
+++ b/modules/betterchairs-api/src/main/java/de/sprax2013/betterchairs/files/Messages.java
@@ -1,5 +1,6 @@
-package de.sprax2013.betterchairs;
+package de.sprax2013.betterchairs.files;
 
+import de.sprax2013.betterchairs.api.ChairManager;
 import de.sprax2013.lime.configuration.Config;
 import de.sprax2013.lime.configuration.ConfigEntry;
 import de.sprax2013.lime.configuration.validation.StringEntryValidator;

--- a/modules/betterchairs-api/src/main/java/de/sprax2013/betterchairs/files/Settings.java
+++ b/modules/betterchairs-api/src/main/java/de/sprax2013/betterchairs/files/Settings.java
@@ -1,5 +1,6 @@
-package de.sprax2013.betterchairs;
+package de.sprax2013.betterchairs.files;
 
+import de.sprax2013.betterchairs.api.ChairManager;
 import de.sprax2013.lime.configuration.Config;
 import de.sprax2013.lime.configuration.ConfigEntry;
 import de.sprax2013.lime.configuration.validation.IntEntryValidator;

--- a/modules/betterchairs-plugin/pom.xml
+++ b/modules/betterchairs-plugin/pom.xml
@@ -44,13 +44,27 @@
                                 </relocation>
 
                                 <relocation>
+                                    <pattern>de.sprax2013.lime</pattern>
+                                    <shadedPattern>de.sprax2013.betterchairs.dependencies.de.sprax2013.lime
+                                    </shadedPattern>
+                                </relocation>
+
+                                <relocation>
+                                    <pattern>de.tr7zw.changeme.nbtapi</pattern>
+                                    <shadedPattern>de.sprax2013.betterchairs.dependencies.de.tr7zw.nbtapi
+                                    </shadedPattern>
+                                </relocation>
+
+                                <relocation>
                                     <pattern>com.cryptomorin.xseries</pattern>
-                                    <shadedPattern>de.sprax2013.betterchairs.cryptomorin.xseries</shadedPattern>
+                                    <shadedPattern>de.sprax2013.betterchairs.dependencies.com.cryptomorin.xseries
+                                    </shadedPattern>
                                 </relocation>
 
                                 <relocation>
                                     <pattern>org.bstats.bukkit</pattern>
-                                    <shadedPattern>de.sprax2013.betterchairs.bstats</shadedPattern>
+                                    <shadedPattern>de.sprax2013.betterchairs.dependencies.org.bstats.bukkit
+                                    </shadedPattern>
                                 </relocation>
                             </relocations>
                         </configuration>

--- a/modules/betterchairs-plugin/src/main/java/de/sprax2013/betterchairs/BetterChairsCommand.java
+++ b/modules/betterchairs-plugin/src/main/java/de/sprax2013/betterchairs/BetterChairsCommand.java
@@ -1,5 +1,7 @@
 package de.sprax2013.betterchairs;
 
+import de.sprax2013.betterchairs.files.Messages;
+import de.sprax2013.betterchairs.files.Settings;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
@@ -9,8 +11,6 @@ import org.bukkit.plugin.java.JavaPlugin;
 
 import java.util.ArrayList;
 import java.util.List;
-
-import static de.sprax2013.betterchairs.BetterChairsPlugin.getManager;
 
 // TODO: Put all strings into messages.yml
 public class BetterChairsCommand implements CommandExecutor, TabCompleter {
@@ -55,7 +55,7 @@ public class BetterChairsCommand implements CommandExecutor, TabCompleter {
                 }
             } else if (args[0].equalsIgnoreCase("reset")) {
                 if (sender.hasPermission(permsReset)) {
-                    int chairCount = getManager().destroyAll(true);
+                    int chairCount = BetterChairsPlugin.getManager().destroyAll(true);
 
                     if (chairCount > 0) {
                         sender.sendMessage(Messages.getPrefix() + " §aSuccessfully removed §6" + chairCount + " players§a from their chairs");
@@ -115,8 +115,8 @@ public class BetterChairsCommand implements CommandExecutor, TabCompleter {
             return;
         }
 
-        boolean nowDisabled = !getManager().hasChairsDisabled((Player) sender);
-        getManager().setChairsDisabled((Player) sender, nowDisabled);
+        boolean nowDisabled = !BetterChairsPlugin.getManager().hasChairsDisabled((Player) sender);
+        BetterChairsPlugin.getManager().setChairsDisabled((Player) sender, nowDisabled);
 
         sender.sendMessage(Messages.getString(nowDisabled ? Messages.TOGGLE_DISABLED : Messages.TOGGLE_ENABLED));
     }

--- a/modules/betterchairs-plugin/src/main/java/de/sprax2013/betterchairs/BetterChairsPlugin.java
+++ b/modules/betterchairs-plugin/src/main/java/de/sprax2013/betterchairs/BetterChairsPlugin.java
@@ -1,5 +1,10 @@
 package de.sprax2013.betterchairs;
 
+import de.sprax2013.betterchairs.api.ChairManager;
+import de.sprax2013.betterchairs.api.ChairNMS;
+import de.sprax2013.betterchairs.api.ChairUtils;
+import de.sprax2013.betterchairs.files.Messages;
+import de.sprax2013.betterchairs.files.Settings;
 import de.sprax2013.lime.spigot.LimeDevUtilitySpigot;
 import de.tr7zw.changeme.nbtapi.utils.MinecraftVersion;
 import org.bstats.bukkit.Metrics;
@@ -51,7 +56,7 @@ public class BetterChairsPlugin extends JavaPlugin {
         new Updater(this);
 
         // Register Bukkit Event Listener
-        Bukkit.getPluginManager().registerEvents(new EventListener(), this);
+        Bukkit.getPluginManager().registerEvents(new EventListener(chairNMS), this);
 
         // Register CommandExecutor
         BetterChairsCommand cmdExecutor = new BetterChairsCommand(this);
@@ -81,8 +86,6 @@ public class BetterChairsPlugin extends JavaPlugin {
         Messages.reset();
 
         chairManager = null;
-        ChairManager.instance = null;
-        ChairManager.plugin = null;
     }
 
     /**

--- a/modules/betterchairs-plugin/src/main/java/de/sprax2013/betterchairs/EventListener.java
+++ b/modules/betterchairs-plugin/src/main/java/de/sprax2013/betterchairs/EventListener.java
@@ -1,6 +1,11 @@
 package de.sprax2013.betterchairs;
 
 import com.cryptomorin.xseries.XMaterial;
+import de.sprax2013.betterchairs.api.Chair;
+import de.sprax2013.betterchairs.api.ChairManager;
+import de.sprax2013.betterchairs.api.ChairNMS;
+import de.sprax2013.betterchairs.files.Messages;
+import de.sprax2013.betterchairs.files.Settings;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
@@ -34,9 +39,13 @@ public class EventListener implements Listener {
             XMaterial.BIRCH_WALL_SIGN, XMaterial.DARK_OAK_WALL_SIGN, XMaterial.JUNGLE_WALL_SIGN,
             XMaterial.OAK_WALL_SIGN, XMaterial.SPRUCE_WALL_SIGN);
 
+    private final ChairNMS chairNMS;
+
     private List<Material> filteredMaterials;
 
-    public EventListener() {
+    public EventListener(ChairNMS chairNMS) {
+        this.chairNMS = chairNMS;
+
         Runnable task = () -> {
             if (Settings.MATERIAL_FILTER_ENABLED.getValueAsBoolean()) {
                 getMaterialFilter();    // Populate list to make sure invalid materials are logged
@@ -98,7 +107,7 @@ public class EventListener implements Listener {
         if (e.getPlayer().getVehicle() != null) return; // Already sitting on something else
         if (!e.getPlayer().hasPermission(BetterChairsPlugin.getInstance().getName() + ".use")) return;
         if (Settings.NEEDS_EMPTY_HANDS.getValueAsBoolean() &&
-                !getManager().chairNMS.hasEmptyHands(e.getPlayer())) return;
+                !this.chairNMS.hasEmptyHands(e.getPlayer())) return;
         if (Settings.ALLOWED_DISTANCE_TO_CHAIR.getValueAsInt() > 0 &&
                 e.getPlayer().getLocation()
                         .distance(e.getClickedBlock().getLocation()
@@ -119,8 +128,8 @@ public class EventListener implements Listener {
         /* Check Block */
         if ((!Settings.MATERIAL_FILTER_ENABLED.getValueAsBoolean() ||
                 !Settings.MATERIAL_FILTER_ALLOW_ALL_TYPES.getValueAsBoolean()) &&
-                !getManager().chairNMS.isStair(e.getClickedBlock()) &&
-                !getManager().chairNMS.isSlab(e.getClickedBlock())) return; // Not a Stair or Slab
+                !this.chairNMS.isStair(e.getClickedBlock()) &&
+                !this.chairNMS.isSlab(e.getClickedBlock())) return; // Not a Stair or Slab
 
         if (!e.getClickedBlock().getRelative(BlockFace.UP).isEmpty() &&
                 Settings.CHAIR_NEED_AIR_ABOVE.getValueAsBoolean()) return;  // Needs air above chair
@@ -128,19 +137,20 @@ public class EventListener implements Listener {
         if (e.getClickedBlock().getRelative(BlockFace.DOWN).isEmpty() &&
                 !Settings.CHAIR_ALLOW_AIR_BELOW.getValueAsBoolean()) return;    // Does not allow air below chair
 
-        if (!getManager().chairNMS.isStair(e.getClickedBlock()) &&
-                !getManager().chairNMS.isSlab(e.getClickedBlock())) return; // Not a Stair or Slab
+        if (!this.chairNMS.isStair(e.getClickedBlock()) &&
+                !this.chairNMS.isSlab(e.getClickedBlock())) return; // Not a Stair or Slab
 
         // Block type disabled in config?
         if (!Settings.MATERIAL_FILTER_ENABLED.getValueAsBoolean() ||
                 (Settings.MATERIAL_FILTER_ENABLED.getValueAsBoolean() &&
                         !Settings.MATERIAL_FILTER_ALLOW_ALL_TYPES.getValueAsBoolean())) {
-            if ((!Settings.USE_STAIRS.getValueAsBoolean() && getManager().chairNMS.isStair(e.getClickedBlock())) ||
-                    (!Settings.USE_SLABS.getValueAsBoolean() && getManager().chairNMS.isSlab(e.getClickedBlock())))
+            if ((!Settings.USE_STAIRS.getValueAsBoolean() && this.chairNMS.isStair(e.getClickedBlock())) ||
+                    (!Settings.USE_SLABS.getValueAsBoolean() && this.chairNMS.isSlab(e.getClickedBlock())))
                 return;
 
-            if (getManager().chairNMS.isStair(e.getClickedBlock()) &&
-                    getManager().chairNMS.isStairUpsideDown(e.getClickedBlock())) return;   // Stair but upside down
+            if (this.chairNMS.isStair(e.getClickedBlock()) &&
+                    this.chairNMS.isStairUpsideDown(e.getClickedBlock()))
+                return;   // Stair but upside down
         }
 
         if (Settings.MATERIAL_FILTER_ENABLED.getValueAsBoolean()) {
@@ -162,7 +172,7 @@ public class EventListener implements Listener {
 
         // Check if Chair needs Signs
         if (Settings.NEEDS_SIGNS.getValueAsBoolean()) {
-            BlockFace rotation = getManager().chairNMS.getBlockRotation(e.getClickedBlock());
+            BlockFace rotation = this.chairNMS.getBlockRotation(e.getClickedBlock());
 
             BlockFace side1 = (rotation == BlockFace.NORTH || rotation == BlockFace.SOUTH) ? BlockFace.WEST : BlockFace.NORTH;
             BlockFace side2 = (rotation == BlockFace.NORTH || rotation == BlockFace.SOUTH) ? BlockFace.EAST : BlockFace.SOUTH;
@@ -181,8 +191,8 @@ public class EventListener implements Listener {
             }
 
             // Are they attached to the chair?
-            if (side1 != getManager().chairNMS.getBlockRotation(block1).getOppositeFace() ||
-                    side2 != getManager().chairNMS.getBlockRotation(block2).getOppositeFace()) {
+            if (side1 != this.chairNMS.getBlockRotation(block1).getOppositeFace() ||
+                    side2 != this.chairNMS.getBlockRotation(block2).getOppositeFace()) {
                 if (Settings.MSG_NEEDS_SIGNS.getValueAsBoolean()) {
                     e.getPlayer().sendMessage(Messages.getString(Messages.USE_NEEDS_SIGNS));
                 }

--- a/modules/betterchairs-plugin/src/main/java/de/sprax2013/betterchairs/Updater.java
+++ b/modules/betterchairs-plugin/src/main/java/de/sprax2013/betterchairs/Updater.java
@@ -1,5 +1,7 @@
 package de.sprax2013.betterchairs;
 
+import de.sprax2013.betterchairs.api.ChairManager;
+import de.sprax2013.betterchairs.files.Settings;
 import net.md_5.bungee.api.ChatColor;
 import net.md_5.bungee.api.chat.ClickEvent;
 import net.md_5.bungee.api.chat.ComponentBuilder;

--- a/modules/nms/betterchairs-v1_10_R1/src/main/java/betterchairs/nms/v1_10_R1.java
+++ b/modules/nms/betterchairs-v1_10_R1/src/main/java/betterchairs/nms/v1_10_R1.java
@@ -1,9 +1,9 @@
 package betterchairs.nms;
 
-import de.sprax2013.betterchairs.ChairManager;
-import de.sprax2013.betterchairs.ChairNMS;
-import de.sprax2013.betterchairs.ChairUtils;
-import de.sprax2013.betterchairs.Messages;
+import de.sprax2013.betterchairs.api.ChairUtils;
+import de.sprax2013.betterchairs.api.ChairManager;
+import de.sprax2013.betterchairs.api.ChairNMS;
+import de.sprax2013.betterchairs.files.Messages;
 import net.minecraft.server.v1_10_R1.Entity;
 import net.minecraft.server.v1_10_R1.EntityArmorStand;
 import net.minecraft.server.v1_10_R1.EntityHuman;

--- a/modules/nms/betterchairs-v1_11_R1/src/main/java/betterchairs/nms/v1_11_R1.java
+++ b/modules/nms/betterchairs-v1_11_R1/src/main/java/betterchairs/nms/v1_11_R1.java
@@ -1,9 +1,9 @@
 package betterchairs.nms;
 
-import de.sprax2013.betterchairs.ChairManager;
-import de.sprax2013.betterchairs.ChairNMS;
-import de.sprax2013.betterchairs.ChairUtils;
-import de.sprax2013.betterchairs.Messages;
+import de.sprax2013.betterchairs.api.ChairUtils;
+import de.sprax2013.betterchairs.api.ChairManager;
+import de.sprax2013.betterchairs.api.ChairNMS;
+import de.sprax2013.betterchairs.files.Messages;
 import net.minecraft.server.v1_11_R1.Entity;
 import net.minecraft.server.v1_11_R1.EntityArmorStand;
 import net.minecraft.server.v1_11_R1.EntityHuman;

--- a/modules/nms/betterchairs-v1_12_R1/src/main/java/betterchairs/nms/v1_12_R1.java
+++ b/modules/nms/betterchairs-v1_12_R1/src/main/java/betterchairs/nms/v1_12_R1.java
@@ -1,9 +1,9 @@
 package betterchairs.nms;
 
-import de.sprax2013.betterchairs.ChairManager;
-import de.sprax2013.betterchairs.ChairNMS;
-import de.sprax2013.betterchairs.ChairUtils;
-import de.sprax2013.betterchairs.Messages;
+import de.sprax2013.betterchairs.api.ChairUtils;
+import de.sprax2013.betterchairs.api.ChairManager;
+import de.sprax2013.betterchairs.api.ChairNMS;
+import de.sprax2013.betterchairs.files.Messages;
 import net.minecraft.server.v1_12_R1.Entity;
 import net.minecraft.server.v1_12_R1.EntityArmorStand;
 import net.minecraft.server.v1_12_R1.EntityHuman;

--- a/modules/nms/betterchairs-v1_13_R2/src/main/java/betterchairs/nms/v1_13_R2.java
+++ b/modules/nms/betterchairs-v1_13_R2/src/main/java/betterchairs/nms/v1_13_R2.java
@@ -1,9 +1,9 @@
 package betterchairs.nms;
 
-import de.sprax2013.betterchairs.ChairManager;
-import de.sprax2013.betterchairs.ChairNMS;
-import de.sprax2013.betterchairs.ChairUtils;
-import de.sprax2013.betterchairs.Messages;
+import de.sprax2013.betterchairs.api.ChairUtils;
+import de.sprax2013.betterchairs.api.ChairManager;
+import de.sprax2013.betterchairs.api.ChairNMS;
+import de.sprax2013.betterchairs.files.Messages;
 import net.minecraft.server.v1_13_R2.Entity;
 import net.minecraft.server.v1_13_R2.EntityArmorStand;
 import net.minecraft.server.v1_13_R2.EntityHuman;

--- a/modules/nms/betterchairs-v1_14_R1/src/main/java/betterchairs/nms/v1_14_R1.java
+++ b/modules/nms/betterchairs-v1_14_R1/src/main/java/betterchairs/nms/v1_14_R1.java
@@ -1,9 +1,9 @@
 package betterchairs.nms;
 
-import de.sprax2013.betterchairs.ChairManager;
-import de.sprax2013.betterchairs.ChairNMS;
-import de.sprax2013.betterchairs.ChairUtils;
-import de.sprax2013.betterchairs.Messages;
+import de.sprax2013.betterchairs.api.ChairUtils;
+import de.sprax2013.betterchairs.api.ChairManager;
+import de.sprax2013.betterchairs.api.ChairNMS;
+import de.sprax2013.betterchairs.files.Messages;
 import net.minecraft.server.v1_14_R1.Entity;
 import net.minecraft.server.v1_14_R1.EntityArmorStand;
 import net.minecraft.server.v1_14_R1.EntityHuman;

--- a/modules/nms/betterchairs-v1_15_R1/src/main/java/betterchairs/nms/v1_15_R1.java
+++ b/modules/nms/betterchairs-v1_15_R1/src/main/java/betterchairs/nms/v1_15_R1.java
@@ -1,9 +1,9 @@
 package betterchairs.nms;
 
-import de.sprax2013.betterchairs.ChairManager;
-import de.sprax2013.betterchairs.ChairNMS;
-import de.sprax2013.betterchairs.ChairUtils;
-import de.sprax2013.betterchairs.Messages;
+import de.sprax2013.betterchairs.api.ChairUtils;
+import de.sprax2013.betterchairs.api.ChairManager;
+import de.sprax2013.betterchairs.api.ChairNMS;
+import de.sprax2013.betterchairs.files.Messages;
 import net.minecraft.server.v1_15_R1.Entity;
 import net.minecraft.server.v1_15_R1.EntityArmorStand;
 import net.minecraft.server.v1_15_R1.EntityHuman;

--- a/modules/nms/betterchairs-v1_16_R1/src/main/java/betterchairs/nms/v1_16_R1.java
+++ b/modules/nms/betterchairs-v1_16_R1/src/main/java/betterchairs/nms/v1_16_R1.java
@@ -1,9 +1,9 @@
 package betterchairs.nms;
 
-import de.sprax2013.betterchairs.ChairManager;
-import de.sprax2013.betterchairs.ChairNMS;
-import de.sprax2013.betterchairs.ChairUtils;
-import de.sprax2013.betterchairs.Messages;
+import de.sprax2013.betterchairs.api.ChairManager;
+import de.sprax2013.betterchairs.api.ChairUtils;
+import de.sprax2013.betterchairs.api.ChairNMS;
+import de.sprax2013.betterchairs.files.Messages;
 import net.minecraft.server.v1_16_R1.Entity;
 import net.minecraft.server.v1_16_R1.EntityArmorStand;
 import net.minecraft.server.v1_16_R1.EntityHuman;

--- a/modules/nms/betterchairs-v1_16_R2/src/main/java/betterchairs/nms/v1_16_R2.java
+++ b/modules/nms/betterchairs-v1_16_R2/src/main/java/betterchairs/nms/v1_16_R2.java
@@ -1,9 +1,9 @@
 package betterchairs.nms;
 
-import de.sprax2013.betterchairs.ChairManager;
-import de.sprax2013.betterchairs.ChairNMS;
-import de.sprax2013.betterchairs.ChairUtils;
-import de.sprax2013.betterchairs.Messages;
+import de.sprax2013.betterchairs.api.ChairManager;
+import de.sprax2013.betterchairs.api.ChairUtils;
+import de.sprax2013.betterchairs.api.ChairNMS;
+import de.sprax2013.betterchairs.files.Messages;
 import net.minecraft.server.v1_16_R2.Entity;
 import net.minecraft.server.v1_16_R2.EntityArmorStand;
 import net.minecraft.server.v1_16_R2.EntityHuman;

--- a/modules/nms/betterchairs-v1_16_R3/src/main/java/betterchairs/nms/v1_16_R3.java
+++ b/modules/nms/betterchairs-v1_16_R3/src/main/java/betterchairs/nms/v1_16_R3.java
@@ -1,9 +1,9 @@
 package betterchairs.nms;
 
-import de.sprax2013.betterchairs.ChairManager;
-import de.sprax2013.betterchairs.ChairNMS;
-import de.sprax2013.betterchairs.ChairUtils;
-import de.sprax2013.betterchairs.Messages;
+import de.sprax2013.betterchairs.api.ChairManager;
+import de.sprax2013.betterchairs.api.ChairUtils;
+import de.sprax2013.betterchairs.api.ChairNMS;
+import de.sprax2013.betterchairs.files.Messages;
 import net.minecraft.server.v1_16_R3.Entity;
 import net.minecraft.server.v1_16_R3.EntityArmorStand;
 import net.minecraft.server.v1_16_R3.EntityHuman;

--- a/modules/nms/betterchairs-v1_8_R1/src/main/java/betterchairs/nms/v1_8_R1.java
+++ b/modules/nms/betterchairs-v1_8_R1/src/main/java/betterchairs/nms/v1_8_R1.java
@@ -1,9 +1,9 @@
 package betterchairs.nms;
 
-import de.sprax2013.betterchairs.ChairManager;
-import de.sprax2013.betterchairs.ChairNMS;
-import de.sprax2013.betterchairs.ChairUtils;
-import de.sprax2013.betterchairs.Messages;
+import de.sprax2013.betterchairs.api.ChairUtils;
+import de.sprax2013.betterchairs.api.ChairManager;
+import de.sprax2013.betterchairs.api.ChairNMS;
+import de.sprax2013.betterchairs.files.Messages;
 import net.minecraft.server.v1_8_R1.EntityArmorStand;
 import net.minecraft.server.v1_8_R1.EntityHuman;
 import net.minecraft.server.v1_8_R1.World;

--- a/modules/nms/betterchairs-v1_8_R2/src/main/java/betterchairs/nms/v1_8_R2.java
+++ b/modules/nms/betterchairs-v1_8_R2/src/main/java/betterchairs/nms/v1_8_R2.java
@@ -1,9 +1,9 @@
 package betterchairs.nms;
 
-import de.sprax2013.betterchairs.ChairManager;
-import de.sprax2013.betterchairs.ChairNMS;
-import de.sprax2013.betterchairs.ChairUtils;
-import de.sprax2013.betterchairs.Messages;
+import de.sprax2013.betterchairs.api.ChairUtils;
+import de.sprax2013.betterchairs.api.ChairManager;
+import de.sprax2013.betterchairs.api.ChairNMS;
+import de.sprax2013.betterchairs.files.Messages;
 import net.minecraft.server.v1_8_R2.EntityArmorStand;
 import net.minecraft.server.v1_8_R2.EntityHuman;
 import net.minecraft.server.v1_8_R2.World;

--- a/modules/nms/betterchairs-v1_8_R3/src/main/java/betterchairs/nms/v1_8_R3.java
+++ b/modules/nms/betterchairs-v1_8_R3/src/main/java/betterchairs/nms/v1_8_R3.java
@@ -1,9 +1,9 @@
 package betterchairs.nms;
 
-import de.sprax2013.betterchairs.ChairManager;
-import de.sprax2013.betterchairs.ChairNMS;
-import de.sprax2013.betterchairs.ChairUtils;
-import de.sprax2013.betterchairs.Messages;
+import de.sprax2013.betterchairs.api.ChairUtils;
+import de.sprax2013.betterchairs.api.ChairManager;
+import de.sprax2013.betterchairs.api.ChairNMS;
+import de.sprax2013.betterchairs.files.Messages;
 import net.minecraft.server.v1_8_R3.EntityArmorStand;
 import net.minecraft.server.v1_8_R3.EntityHuman;
 import net.minecraft.server.v1_8_R3.World;

--- a/modules/nms/betterchairs-v1_9_R1/src/main/java/betterchairs/nms/v1_9_R1.java
+++ b/modules/nms/betterchairs-v1_9_R1/src/main/java/betterchairs/nms/v1_9_R1.java
@@ -1,9 +1,9 @@
 package betterchairs.nms;
 
-import de.sprax2013.betterchairs.ChairManager;
-import de.sprax2013.betterchairs.ChairNMS;
-import de.sprax2013.betterchairs.ChairUtils;
-import de.sprax2013.betterchairs.Messages;
+import de.sprax2013.betterchairs.api.ChairUtils;
+import de.sprax2013.betterchairs.api.ChairManager;
+import de.sprax2013.betterchairs.api.ChairNMS;
+import de.sprax2013.betterchairs.files.Messages;
 import net.minecraft.server.v1_9_R1.Entity;
 import net.minecraft.server.v1_9_R1.EntityArmorStand;
 import net.minecraft.server.v1_9_R1.EntityHuman;

--- a/modules/nms/betterchairs-v1_9_R2/src/main/java/betterchairs/nms/v1_9_R2.java
+++ b/modules/nms/betterchairs-v1_9_R2/src/main/java/betterchairs/nms/v1_9_R2.java
@@ -1,9 +1,9 @@
 package betterchairs.nms;
 
-import de.sprax2013.betterchairs.ChairManager;
-import de.sprax2013.betterchairs.ChairNMS;
-import de.sprax2013.betterchairs.ChairUtils;
-import de.sprax2013.betterchairs.Messages;
+import de.sprax2013.betterchairs.api.ChairUtils;
+import de.sprax2013.betterchairs.api.ChairManager;
+import de.sprax2013.betterchairs.api.ChairNMS;
+import de.sprax2013.betterchairs.files.Messages;
 import net.minecraft.server.v1_9_R2.Entity;
 import net.minecraft.server.v1_9_R2.EntityArmorStand;
 import net.minecraft.server.v1_9_R2.EntityHuman;


### PR DESCRIPTION
**This introduces breaking API-Changes** and requires a major version bump

1. Forgot to put api classes into it's own package
2. LimeDevUtility got shaded twice causing conflicts with other plugins using LimeDevUtility wrongly. All shaded dependencies are now located at `de.sprax2013.betterchairs.depepdencies`

### TODO
* [ ] Update Wiki/Documentation to link and use the new classes/packages (their content hardly changed, but they are located somewhere else now)